### PR TITLE
Downgrade docutils to 0.19

### DIFF
--- a/2.7.3/constraints-3.8.txt
+++ b/2.7.3/constraints-3.8.txt
@@ -271,7 +271,7 @@ distributed==2023.4.1
 dnspython==2.4.2
 docker==6.1.3
 docopt==0.6.2
-docutils==0.20.1
+docutils==0.19
 duckdb==0.9.1
 ecdsa==0.18.0
 elastic-transport==8.10.0


### PR DESCRIPTION
When we are trying to install Sphinx which is pinned to 5.3.0, we get the following dependency error:

```
ERROR: Cannot install sphinx==5.3.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    sphinx 5.3.0 depends on docutils<0.20 and >=0.14
    The user requested (constraint) docutils==0.20.1
```

See https://github.com/apache/airflow/issues/31366